### PR TITLE
Load path on hash change, closes simonw#18

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ useAnalytics && plausible('pageview');
 
 window.onpopstate = function(event) {
   console.log(event);
-  datasetteWorker.postMessage({path: event.target.location.hash.split("#")[1]});
+  datasetteWorker.postMessage({path: event.target.location.hash.split("#")[1] || ""});
 }
 
 // Start with path from location.hash, if available

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@ useAnalytics && plausible('pageview');
 
 window.onpopstate = function(event) {
   console.log(event);
-  datasetteWorker.postMessage({path: event.state.path});
+  datasetteWorker.postMessage({path: event.target.location.hash.split("#")[1]});
 }
 
 // Start with path from location.hash, if available


### PR DESCRIPTION
Using the `hashchange` event doens't work because `popstate` gets in the way, so I modified that function instead. Seems to have not broken anything.

https://user-images.githubusercontent.com/25624882/166852547-e041faab-4507-403e-b126-fb862c3f7b73.mp4

