### PR TITLE
Add more allowed content-types for sqlite download

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,13 +241,13 @@ output.addEventListener('submit', (ev => {
   }
 }), true);
 
-async function checkUrl(url, contentType) {
+async function checkUrl(url, contentTypes) {
   try {
     response = (await fetch(url, {method: 'HEAD'}));
     if (response.status != 200) {
       return false;
     }
-    if (contentType && (response.headers.get('content-type') != contentType)) {
+    if (contentTypes && (!contentTypes.includes(response.headers.get('content-type')))) {
       return false;
     }
     return true;
@@ -263,7 +263,7 @@ document.querySelector('#load-custom button.db-url').addEventListener('click', a
   if (!url) {
     return;
   }
-  let valid = await checkUrl(url, 'application/octet-stream');
+  let valid = await checkUrl(url, ["application/octet-stream", "application/x-sqlite3", "application/vnd.sqlite3"]);
   if (valid) {
     location.href = location.pathname + '?url=' + encodeURIComponent(url);
   } else {


### PR DESCRIPTION
Some sqlite files are hosted with content-types other than `octet-stream`.  So `application/x-sqlite3` and `application/vnd.sqlite3` should probably be allowed as well.