### PR TITLE
POC/Research Prototype: Use createLazyFile to mount a read only view of remote sqlite databases

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,9 +234,10 @@ output.addEventListener('submit', (ev => {
   console.log(ev);
   ev.stopPropagation();
   ev.preventDefault();
-  
+
   // Show loading indicator
   document.getElementById('loading-indicator').style.display = 'block';
+  loadingLogs = [];
   window.scrollTo(0, 0);
 
   if (ev.target && ev.target.nodeName == "FORM" && ev.target.method.toLowerCase() == "get") {

--- a/index.html
+++ b/index.html
@@ -234,7 +234,11 @@ output.addEventListener('submit', (ev => {
   console.log(ev);
   ev.stopPropagation();
   ev.preventDefault();
+  
+  // Show loading indicator
   document.getElementById('loading-indicator').style.display = 'block';
+  window.scrollTo(0, 0);
+
   if (ev.target && ev.target.nodeName == "FORM" && ev.target.method.toLowerCase() == "get") {
     let qs = new URLSearchParams(new FormData(ev.target)).toString();
     let action = ev.target.getAttribute("action");

--- a/index.html
+++ b/index.html
@@ -234,6 +234,7 @@ output.addEventListener('submit', (ev => {
   console.log(ev);
   ev.stopPropagation();
   ev.preventDefault();
+  document.getElementById('loading-indicator').style.display = 'block';
   if (ev.target && ev.target.nodeName == "FORM" && ev.target.method.toLowerCase() == "get") {
     let qs = new URLSearchParams(new FormData(ev.target)).toString();
     let action = ev.target.getAttribute("action");

--- a/webworker.js
+++ b/webworker.js
@@ -113,6 +113,7 @@ async function startDatasette(settings) {
     from datasette.app import Datasette
     ds = Datasette(names, settings={
         "num_sql_threads": 0,
+        "sql_time_limit_ms": 100000,
     }, metadata = {
         "about": "Datasette Lite",
         "about_url": "https://github.com/simonw/datasette-lite"

--- a/webworker.js
+++ b/webworker.js
@@ -41,7 +41,7 @@ function createLazyFileSqlite(parent, name, url, canRead, canWrite, FS) {
 // #if SMALL_XHR_CHUNKS
     // var chunkSize = 1024; // Chunk size in bytes
 // Match default SQLite Page size
-    var chunkSize = 4096; // Chunk size in bytes
+    var chunkSize = 4096 * 5; // Chunk size in bytes
 // #else
 //     var chunkSize = 1024*1024; // Chunk size in bytes
 // #endif

--- a/webworker.js
+++ b/webworker.js
@@ -282,7 +282,7 @@ async function startDatasette(settings) {
     from datasette.app import Datasette
     ds = Datasette(names, settings={
         "num_sql_threads": 0,
-        "sql_time_limit_ms": 600000,
+        "sql_time_limit_ms": 1200000,
     }, metadata = {
         "about": "Datasette Lite",
         "about_url": "https://github.com/simonw/datasette-lite"

--- a/webworker.js
+++ b/webworker.js
@@ -282,7 +282,7 @@ async function startDatasette(settings) {
     from datasette.app import Datasette
     ds = Datasette(names, settings={
         "num_sql_threads": 0,
-        "sql_time_limit_ms": 400000,
+        "sql_time_limit_ms": 600000,
     }, metadata = {
         "about": "Datasette Lite",
         "about_url": "https://github.com/simonw/datasette-lite"

--- a/webworker.js
+++ b/webworker.js
@@ -286,7 +286,7 @@ async function startDatasette(settings) {
             url: url
           }
       },
-      requestChunkSize: 4096,
+      requestChunkSize: 12288,
     })
   }
 

--- a/webworker.js
+++ b/webworker.js
@@ -41,7 +41,7 @@ function createLazyFileSqlite(parent, name, url, canRead, canWrite, FS) {
 // #if SMALL_XHR_CHUNKS
     // var chunkSize = 1024; // Chunk size in bytes
 // Match default SQLite Page size
-    var chunkSize = 4096 * 5; // Chunk size in bytes
+    var chunkSize = 4096 * 10; // Chunk size in bytes
 // #else
 //     var chunkSize = 1024*1024; // Chunk size in bytes
 // #endif

--- a/webworker.js
+++ b/webworker.js
@@ -282,7 +282,7 @@ async function startDatasette(settings) {
     from datasette.app import Datasette
     ds = Datasette(names, settings={
         "num_sql_threads": 0,
-        "sql_time_limit_ms": 100000,
+        "sql_time_limit_ms": 400000,
     }, metadata = {
         "about": "Datasette Lite",
         "about_url": "https://github.com/simonw/datasette-lite"

--- a/webworker.js
+++ b/webworker.js
@@ -169,7 +169,7 @@ class LazyUint8Array {
       return this._chunkSize;
   }
   doXHR(absoluteFrom, absoluteTo) {
-      console.log(`[xhr of size ${(absoluteTo + 1 - absoluteFrom) / 1024} KiB @ ${absoluteFrom / 1024} KiB]`);
+      log(`[xhr of size ${(absoluteTo + 1 - absoluteFrom) / 1024} KiB @ ${absoluteFrom / 1024} KiB]`);
       this.requestLimiter(absoluteTo - absoluteFrom);
       this.totalFetchedBytes += absoluteTo - absoluteFrom;
       this.totalRequests++;

--- a/webworker.js
+++ b/webworker.js
@@ -5,6 +5,175 @@ function log(line) {
   self.postMessage({type: 'log', line: line});
 }
 
+// Extracted from https://github.com/emscripten-core/emscripten/blob/0c070488619cf556e4917cd88c0a868faf611c13/src/library_fs.js#L1675
+// * Tuned chunk size to match SQLite default chunk size
+// * Commented out emscripten build concerns
+// * Allow emscripten FS to be injected in
+function createLazyFileSqlite(parent, name, url, canRead, canWrite, FS) {
+  // Lazy chunked Uint8Array (implements get and length from Uint8Array). Actual getting is abstracted away for eventual reuse.
+  /** @constructor */
+  function LazyUint8Array() {
+    this.lengthKnown = false;
+    this.chunks = []; // Loaded chunks. Index is the chunk number
+  }
+  LazyUint8Array.prototype.get = /** @this{Object} */ function LazyUint8Array_get(idx) {
+    if (idx > this.length-1 || idx < 0) {
+      return undefined;
+    }
+    var chunkOffset = idx % this.chunkSize;
+    var chunkNum = (idx / this.chunkSize)|0;
+    return this.getter(chunkNum)[chunkOffset];
+  };
+  LazyUint8Array.prototype.setDataGetter = function LazyUint8Array_setDataGetter(getter) {
+    this.getter = getter;
+  };
+  LazyUint8Array.prototype.cacheLength = function LazyUint8Array_cacheLength() {
+    // Find length
+    var xhr = new XMLHttpRequest();
+    xhr.open('HEAD', url, false);
+    xhr.send(null);
+    if (!(xhr.status >= 200 && xhr.status < 300 || xhr.status === 304)) throw new Error("Couldn't load " + url + ". Status: " + xhr.status);
+    var datalength = Number(xhr.getResponseHeader("Content-length"));
+    var header;
+    var hasByteServing = (header = xhr.getResponseHeader("Accept-Ranges")) && header === "bytes";
+    var usesGzip = (header = xhr.getResponseHeader("Content-Encoding")) && header === "gzip";
+
+// #if SMALL_XHR_CHUNKS
+    // var chunkSize = 1024; // Chunk size in bytes
+// Match default SQLite Page size
+    var chunkSize = 4096; // Chunk size in bytes
+// #else
+//     var chunkSize = 1024*1024; // Chunk size in bytes
+// #endif
+
+    if (!hasByteServing) chunkSize = datalength;
+
+    // Function to get a range from the remote URL.
+    var doXHR = (function(from, to) {
+      if (from > to) throw new Error("invalid range (" + from + ", " + to + ") or no bytes requested!");
+      if (to > datalength-1) throw new Error("only " + datalength + " bytes available! programmer error!");
+
+      // TODO: Use mozResponseArrayBuffer, responseStream, etc. if available.
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', url, false);
+      if (datalength !== chunkSize) xhr.setRequestHeader("Range", "bytes=" + from + "-" + to);
+
+      // Some hints to the browser that we want binary data.
+      if (typeof Uint8Array != 'undefined') xhr.responseType = 'arraybuffer';
+      if (xhr.overrideMimeType) {
+        xhr.overrideMimeType('text/plain; charset=x-user-defined');
+      }
+
+      xhr.send(null);
+      if (!(xhr.status >= 200 && xhr.status < 300 || xhr.status === 304)) throw new Error("Couldn't load " + url + ". Status: " + xhr.status);
+      if (xhr.response !== undefined) {
+        return new Uint8Array(/** @type{Array<number>} */(xhr.response || []));
+      } else {
+        return intArrayFromString(xhr.responseText || '', true);
+      }
+    });
+    var lazyArray = this;
+    lazyArray.setDataGetter(function(chunkNum) {
+      var start = chunkNum * chunkSize;
+      var end = (chunkNum+1) * chunkSize - 1; // including this byte
+      end = Math.min(end, datalength-1); // if datalength-1 is selected, this is the last block
+      if (typeof(lazyArray.chunks[chunkNum]) === "undefined") {
+        lazyArray.chunks[chunkNum] = doXHR(start, end);
+      }
+      if (typeof(lazyArray.chunks[chunkNum]) === "undefined") throw new Error("doXHR failed!");
+      return lazyArray.chunks[chunkNum];
+    });
+
+    if (usesGzip || !datalength) {
+      // if the server uses gzip or doesn't supply the length, we have to download the whole file to get the (uncompressed) length
+      chunkSize = datalength = 1; // this will force getter(0)/doXHR do download the whole file
+      datalength = this.getter(0).length;
+      chunkSize = datalength;
+      out("LazyFiles on gzip forces download of the whole file when length is accessed");
+    }
+
+    this._length = datalength;
+    this._chunkSize = chunkSize;
+    this.lengthKnown = true;
+  };
+  if (typeof XMLHttpRequest !== 'undefined') {
+    // if (!ENVIRONMENT_IS_WORKER) throw 'Cannot do synchronous binary XHRs outside webworkers in modern browsers. Use --embed-file or --preload-file in emcc';
+    var lazyArray = new LazyUint8Array();
+    Object.defineProperties(lazyArray, {
+      length: {
+        get: /** @this{Object} */ function() {
+          if (!this.lengthKnown) {
+            this.cacheLength();
+          }
+          return this._length;
+        }
+      },
+      chunkSize: {
+        get: /** @this{Object} */ function() {
+          if (!this.lengthKnown) {
+            this.cacheLength();
+          }
+          return this._chunkSize;
+        }
+      }
+    });
+
+    var properties = { isDevice: false, contents: lazyArray };
+  } else {
+    var properties = { isDevice: false, url: url };
+  }
+
+  var node = FS.createFile(parent, name, properties, canRead, canWrite);
+  // This is a total hack, but I want to get this lazy file code out of the
+  // core of MEMFS. If we want to keep this lazy file concept I feel it should
+  // be its own thin LAZYFS proxying calls to MEMFS.
+  if (properties.contents) {
+    node.contents = properties.contents;
+  } else if (properties.url) {
+    node.contents = null;
+    node.url = properties.url;
+  }
+  // Add a function that defers querying the file size until it is asked the first time.
+  Object.defineProperties(node, {
+    usedBytes: {
+      get: /** @this {FSNode} */ function() { return this.contents.length; }
+    }
+  });
+  // override each stream op with one that tries to force load the lazy file first
+  var stream_ops = {};
+  var keys = Object.keys(node.stream_ops);
+  keys.forEach(function(key) {
+    var fn = node.stream_ops[key];
+    stream_ops[key] = function forceLoadLazyFile() {
+      FS.forceLoadFile(node);
+      return fn.apply(null, arguments);
+    };
+  });
+  // use a custom read function
+  stream_ops.read = function stream_ops_read(stream, buffer, offset, length, position) {
+    FS.forceLoadFile(node);
+    var contents = stream.node.contents;
+    if (position >= contents.length)
+      return 0;
+    var size = Math.min(contents.length - position, length);
+// #if ASSERTIONS
+//     assert(size >= 0);
+// #endif
+    if (contents.slice) { // normal array
+      for (var i = 0; i < size; i++) {
+        buffer[offset + i] = contents[position + i];
+      }
+    } else {
+      for (var i = 0; i < size; i++) { // LazyUint8Array from sync binary XHR
+        buffer[offset + i] = contents.get(position + i);
+      }
+    }
+    return size;
+  };
+  node.stream_ops = stream_ops;
+  return node;
+}
+
 async function startDatasette(settings) {
   let toLoad = [];
   let toMount = [];
@@ -39,7 +208,7 @@ async function startDatasette(settings) {
   });
 
   for (let [name, url] of toMount) {
-    pyodide.FS.createLazyFile('/home/pyodide', name, url, true, false)
+    createLazyFileSqlite('/home/pyodide', name, url, true, false, pyodide.FS)
   }
 
   await pyodide.loadPackage('micropip', log);


### PR DESCRIPTION
This is more POC/WIP/curiosity than anything serious. Just wanted to make a draft PR for posterity.

---

For context, I'm trying to put a 32GB FTS5 sqlite database on the internet to query. I plan to host it on Cloudflare so I do not care about BW costs.

The functionality here is a bit like https://github.com/phiresky/sql.js-httpvfs, but far lazier and inefficient. I originally thought I would have to make my own GUI, but I kind of like the GUI I saw in datasette and wondered if I could reuse it. Unfortunately, current `datasette-lite` seems to pull everything into memory.

It does work actually, but I don't know how viable this is. Emscripten is by default reads 1MB chunks but it seems to have some way to recompile it to not:

https://github.com/emscripten-core/emscripten/blob/18bc868cb5242e6816a4b3bde74b1e1dcd6fd818/src/library_fs.js#L1713

https://github.com/azavea/loam/issues/75#issuecomment-888515090

Some FTS5 queries take 1GB to query while others may take only 66MB. As I've said, I don't care about BW but the great inefficiency harms UX.

Also, this chunked inefficiency means that I have to hack the URL to not load tables of a database as it seems to try to load the whole database when I click on a database.

I think for my goal, I might have to try to recompile pyodide with a small XHR build of emscripten. 😬 

As for any dependencies from the remote URLs, they'll need to have the proper CORS headers set, including "expose" headers. If it can't read expose headers or the remote file is GZIPed, it just downloads the whole file, so it does degrade gracefully. However, it does cause a nasty error message in the console to popup saying something denied access to some headers to Emscripten. 

Anyway, this is just for fun.
