### PR TITLE
Upgrade to Pyodide 0.22.1

### DIFF
--- a/webworker.js
+++ b/webworker.js
@@ -1,4 +1,4 @@
-importScripts("https://cdn.jsdelivr.net/pyodide/v0.20.0/full/pyodide.js");
+importScripts("https://cdn.jsdelivr.net/pyodide/v0.22.1/full/pyodide.js");
 
 function log(line) {
   console.log({line})
@@ -40,7 +40,8 @@ async function startDatasette(settings) {
     toLoad.push(["content.db", "https://datasette.io/content.db"]);
   }
   self.pyodide = await loadPyodide({
-    indexURL: "https://cdn.jsdelivr.net/pyodide/v0.20.0/full/"
+    indexURL: "https://cdn.jsdelivr.net/pyodide/v0.22.1/full/",
+    fullStdLib: true
   });
   await pyodide.loadPackage('micropip', log);
   await pyodide.loadPackage('ssl', log);


### PR DESCRIPTION
Related to #41 and #42.

Bundles `sqlite` version 3.39.0, providing the full JSON extension (including functions and operators such as `->>` and `->`).