### PR TITLE
Add params to add full text search and drop unwanted columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,10 @@ const sqlUrls = urlParams.getAll('sql').map(fixUrl);
 const jsonUrls = urlParams.getAll('json').map(fixUrl);
 const parquetUrls = urlParams.getAll('parquet').map(fixUrl);
 const installUrls = urlParams.getAll('install');
+const ftsCols = urlParams.get('fts');
+const dropCols = urlParams.get('drop');
 
-datasetteWorker.postMessage({type: 'startup', initialUrl, memory, csvUrls, sqlUrls, jsonUrls, parquetUrls, installUrls, metadataUrl});
+datasetteWorker.postMessage({type: 'startup', initialUrl, memory, csvUrls, sqlUrls, jsonUrls, parquetUrls, installUrls, metadataUrl, ftsCols, dropCols});
 
 let loadingLogs = ["Loading..."];
 

--- a/webworker.js
+++ b/webworker.js
@@ -152,6 +152,14 @@ async function startDatasette(settings) {
                         fp.write(await response.bytes())
                     df = fastparquet.ParquetFile("parquet.parquet").to_pandas()
                     df.to_sql(bit, db.conn, if_exists="replace")
+                fts_cols = ${JSON.stringify(settings.ftsCols || "")}
+                try:
+                    db[bit].enable_fts(fts_cols.split(","))
+                except sqlite3.OperationalError:
+                    print("Column not found")
+                    pass
+                drop_cols = ${JSON.stringify(settings.dropCols || "")}
+                db[bit].transform(drop=set(drop_cols.split(",")))
     from datasette.app import Datasette
     ds = Datasette(names, settings={
         "num_sql_threads": 0,


### PR DESCRIPTION
Don't know if you want to include this, but I'm finding it handy in my own fork, so I thought I'd submit it for consideration. 

This pull request adds two new url parameters:

- `fts`: column/s that you want to have a full text index (multiple values separated by commas)
- `drop`: column/s that you want to drop from the db (multiple values separated by commas)

For example, this url opens a CSV dataset with oral history metadata, indexes the `title` column, and drops the `publisher` column: <https://glam-workbench.net/datasette-lite/?csv=https://github.com/GLAM-Workbench/trove-oral-histories-data/blob/main/trove-oral-histories.csv&fts=title&drop=publisher>

See also my [GLAM Workbench Datasette-Lite fork](https://github.com/GLAM-Workbench/datasette-lite).