### PR TITLE
fix: bump python-multipart dependency

### DIFF
--- a/webworker.js
+++ b/webworker.js
@@ -72,7 +72,7 @@ async function startDatasette(settings) {
     # Workaround for Requested 'h11<0.13,>=0.11', but h11==0.13.0 is already installed
     await micropip.install("h11==0.12.0")
     await micropip.install("httpx==0.23")
-    await micropip.install("python-multipart==0.0.12")
+    await micropip.install("python-multipart==0.0.15")
     # To avoid possible 'from typing_extensions import deprecated' error:
     await micropip.install('typing-extensions>=4.12.2')
     await micropip.install("${datasetteToInstall}", pre=${pre})


### PR DESCRIPTION
This fixes #80 

It turns out the strategy of getting the wheel from pypi, is the fault here, but also potentially https://github.com/simonw/datasette-lite/commit/4b948aaeec3348fe2f7b7d98f165966daec6b345

All I did was this. If interested I have a few more commits that might help make dev experience easier on this repo.

In any case, this should fix https://lite.datasette.io/

![Screenshot of fix, showing this working, using the Darkreader plugin](https://github.com/user-attachments/assets/f72d1af8-3fa3-4a9d-8832-48cc0a0fe59d)
